### PR TITLE
UserGuide - workaround broken link to Widget Servlet property

### DIFF
--- a/userGuide/en/chapters/20-properties-reference.markdown
+++ b/userGuide/en/chapters/20-properties-reference.markdown
@@ -4784,7 +4784,7 @@ Set this property to `true` to enable directory indexing.
 
 	web.server.servlet.directory.indexing.enabled=false	
 
-## Widget Servlet [](id=widget-servlet)
+## Widget Servlet [](id=lp-6-1-ugen20-widget-servlet-0)
 
 Set the servlet mapping for the widget servlet.
 


### PR DESCRIPTION
Please merge this in with the re-org changes to the user guide. As Mark may have pointed out to you, the link to Widget Servlet section in the properties reference chapter is broken on liferay.com at http://www.liferay.com/documentation/liferay-portal/6.1/user-guide/-/ai/widget-servlet . It was also broken on staging. I've replaced the ID as a workaround and staging is good now.
