### PR TITLE
LRDOCS-3978 Spring mvc portlet classpath improvements

### DIFF
--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/04-upgrading-portlet-plugins/07-upgrading-a-spring-mvc-portlet.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/04-upgrading-portlet-plugins/07-upgrading-a-spring-mvc-portlet.markdown
@@ -89,7 +89,22 @@ Some of `my-spring-mvc-portlet`'s dependency artifacts have new names.
  `spring-web-portlet` | `spring-webmvc-portlet` |
  `spring-web-servlet` | `spring-webmvc` |
 
-[Maven Central](https://search.maven.org/) provides artifact dependency information. 
+[Maven Central](https://search.maven.org/) provides artifact dependency
+information. 
+
++$$$
+
+**Note**: If the Spring Framework version you're using differs from the version
+@product@ uses, you must rename your Spring Framework JARs differently from the
+ones
+[portal property `module.framework.web.generator.excluded.paths`](https://docs.liferay.com/ce/portal/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework)
+excludes. If you don't rename your Spring Framework JARs, @product@ assumes
+you're using its Spring Framework JARs and excludes yours from the generated
+WAB (Web Application Bundle).
+[Understanding Excluded JARs](/develop/tutorials/-/knowledge_base/7-0/resolving-a-plugins-dependencies#understanding-excluded-jars)
+explains how to detect @product@'s Spring Framework version. 
+
+$$$
 
 +$$$
 
@@ -104,6 +119,32 @@ portlet's `liferay-plugin-package.properties` file's `deploy-excludes` property.
 
 Since `my-spring-mvc-portlet`'s dependencies aren't OSGi modules, no JARs
 must be excluded.
+
+$$$
+
+Make sure to import class packages the descriptor files reference by adding the
+packages to an `Import-Package` header in the portlet's
+`liferay-plugin-package.properties` file. See 
+[Packaging a Spring MVC Portlet](/develop/tutorials/-/knowledge_base/7-0/spring-mvc#packaging-a-spring-mvc-portlet)
+for details.
+
+If you depend on a package from Java's `rt.jar` other than a `java.*` packages,
+override
+[portal property `org.osgi.framework.bootdelegation`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework)
+and add it to the property's list. Go [here](/develop/tutorials/-/knowledge_base/7-0/resolving-classnotfoundexception-and-noclassdeffounderror-in-osgi-bundles#case-4-the-missing-class-belongs-to-a-java-runtime-package)
+for details. 
+
++$$$
+
+**Note**: Spring MVC portlets whose embedded JARs contain properties files (e.g., `spring.handlers`, `spring.schemas`, `spring.tooling`) might
+be affected by issue
+[LPS-75212](https://issues.liferay.com/browse/LPS-75212).
+The last JAR that has properties files is the only JAR whose properties are
+added to the resulting WAB's classpath. Properties in other JARs aren't added.
+
+See 
+[Packaging a Spring MVC Portlet](/develop/tutorials/-/knowledge_base/7-0/spring-mvc#packaging-a-spring-mvc-portlet)
+for a workaround and details.
 
 $$$
 

--- a/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/04-upgrading-portlet-plugins/07-upgrading-a-spring-mvc-portlet.markdown
+++ b/develop/tutorials/articles/02-from-liferay-6-to-liferay-7/07-upgrading-plugins-to-liferay-7/04-upgrading-portlet-plugins/07-upgrading-a-spring-mvc-portlet.markdown
@@ -95,14 +95,14 @@ information.
 +$$$
 
 **Note**: If the Spring Framework version you're using differs from the version
-@product@ uses, you must rename your Spring Framework JARs differently from the
-ones
-[portal property `module.framework.web.generator.excluded.paths`](https://docs.liferay.com/ce/portal/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework)
-excludes. If you don't rename your Spring Framework JARs, @product@ assumes
-you're using its Spring Framework JARs and excludes yours from the generated
-WAB (Web Application Bundle).
+@product@ uses, you must rename your Spring Framework JARs differently from
+@product@'s Spring Framework JARs. If you don't rename your JARs, @product@
+assumes you're using its Spring Framework JARs and excludes yours from the
+generated WAB (Web Application Bundle).
+[Portal property `module.framework.web.generator.excluded.paths`](https://docs.liferay.com/ce/portal/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework)
+lists @product@'s Spring Framework JARs. 
 [Understanding Excluded JARs](/develop/tutorials/-/knowledge_base/7-0/resolving-a-plugins-dependencies#understanding-excluded-jars)
-explains how to detect @product@'s Spring Framework version. 
+explains how to detect the Spring Framework version @product@ uses. 
 
 $$$
 
@@ -122,29 +122,29 @@ must be excluded.
 
 $$$
 
-Make sure to import class packages the descriptor files reference by adding the
-packages to an `Import-Package` header in the portlet's
+Import class packages your portlet's descriptor files reference by adding the
+packages to an `Import-Package` header in the
 `liferay-plugin-package.properties` file. See 
 [Packaging a Spring MVC Portlet](/develop/tutorials/-/knowledge_base/7-0/spring-mvc#packaging-a-spring-mvc-portlet)
 for details.
 
-If you depend on a package from Java's `rt.jar` other than a `java.*` packages,
-override
+If you depend on a package from Java's `rt.jar` other than its `java.*`
+packages, override
 [portal property `org.osgi.framework.bootdelegation`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework)
 and add it to the property's list. Go [here](/develop/tutorials/-/knowledge_base/7-0/resolving-classnotfoundexception-and-noclassdeffounderror-in-osgi-bundles#case-4-the-missing-class-belongs-to-a-java-runtime-package)
 for details. 
 
 +$$$
 
-**Note**: Spring MVC portlets whose embedded JARs contain properties files (e.g., `spring.handlers`, `spring.schemas`, `spring.tooling`) might
-be affected by issue
+**Note**: Spring MVC portlets whose embedded JARs contain properties files
+(e.g., `spring.handlers`, `spring.schemas`, `spring.tooling`) might be affected
+by issue
 [LPS-75212](https://issues.liferay.com/browse/LPS-75212).
 The last JAR that has properties files is the only JAR whose properties are
 added to the resulting WAB's classpath. Properties in other JARs aren't added.
 
-See 
 [Packaging a Spring MVC Portlet](/develop/tutorials/-/knowledge_base/7-0/spring-mvc#packaging-a-spring-mvc-portlet)
-for a workaround and details.
+explains how to add all the embedded JAR properties.
 
 $$$
 

--- a/develop/tutorials/articles/110-portlets/03-spring-mvc/00-spring-mvc-intro.markdown
+++ b/develop/tutorials/articles/110-portlets/03-spring-mvc/00-spring-mvc-intro.markdown
@@ -45,8 +45,8 @@ and `liferay-portlet.xml`, and you'll need a `portlet.xml` descriptor.
 
 Develop a Spring MVC portlet WAR file with the appropriate descriptor files. 
 
-Make sure to import class packages the descriptor files reference by adding the
-packages to an `Import-Package` header in the portlet's
+Import class packages your portlet's descriptor files reference by adding the
+packages to an `Import-Package` header in the
 `liferay-plugin-package.properties` file. 
 
 Here's an example `Import-Package` header:
@@ -58,11 +58,11 @@ Here's an example `Import-Package` header:
         org.springframework.web.servlet.config.MvcNamespaceHandler
 
 The auto-deploy process and Liferay's WAB generator convert your project to a
-Liferay-ready WAB. The WAB generator merges
-`liferay-plugin-package.properties`'s packages with the packages the portlet's
-classes import to produce the WAB manifest's `Import-Package` header.
+Liferay-ready WAB. The WAB generator producees the WAB manifest's
+`Import-Package` header by merging `liferay-plugin-package.properties`'s
+packages with the packages your portlet's classes import.
 
-If you depend on a package from Java's `rt.jar` other than a `java.*` packages,
+If you depend on a package from Java's `rt.jar` other than a `java.*` package,
 override
 [portal property `org.osgi.framework.bootdelegation`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework)
 and add it to the property's list. Go [here](/develop/tutorials/-/knowledge_base/7-0/resolving-classnotfoundexception-and-noclassdeffounderror-in-osgi-bundles#case-4-the-missing-class-belongs-to-a-java-runtime-package)
@@ -70,11 +70,12 @@ for details.
 
 +$$$
 
-**Note**: Spring MVC portlets whose embedded JARs contain properties files might
-be affected by issue
+**Note**: Spring MVC portlets whose embedded JARs contain properties files
+(e.g., `spring.handlers`, `spring.schemas`, `spring.tooling`) might be affected
+by issue
 [LPS-75212](https://issues.liferay.com/browse/LPS-75212).
 The last JAR that has properties files is the only JAR whose properties are
-added to the module's classpath. Properties in other JARs aren't added. 
+added to the resulting WAB's classpath. Properties in other JARs aren't added. 
 
 For example, a portlet has several JARs containing these properties files:
 
@@ -83,7 +84,7 @@ For example, a portlet has several JARs containing these properties files:
 -   `WEB-INF/src/META-INF/spring.tooling`
 
 The properties from the last JAR processed are the only ones added to the
-classpath. The module can only use properties whose files are in the classpath.
+classpath. The properties files must be on the classpath for the module to use.
 
 To add all the properties files to the classpath, you can combine them into one
 of each type (e.g., one `spring.handlers`, one `spring.schemas`, and one

--- a/develop/tutorials/articles/310-troubleshooting/03-resolving-cnfe-and-cdnfe-in-osgi-bundles.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/03-resolving-cnfe-and-cdnfe-in-osgi-bundles.markdown
@@ -116,14 +116,14 @@ already be be exported if Liferay intended for it to be available.
 In this case, the class belongs to Java's `rt.jar` but the package isn't
 specified in the OSGi Framework's boot delegation list. `rt.jar`'s `java.*`
 packages are its only ones available on the classpath automatically; its other
-packages must be specified in the boot delegation list be on the classpath.
+packages must be specified in the boot delegation list to get on the classpath.
 
 Here's how to add packages to the boot delegation list:
 
 1.  In a `portal-ext.properties` file, override
     [portal property `org.osgi.framework.bootdelegation`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework).
-    Preserve its current list. 
-2.  Add the missing class's package to the list. 
+    Preserve the property's current list. 
+2.  Add the missing package to the list. 
 
 ## Related Topics [](id=related-topics)
 

--- a/develop/tutorials/articles/310-troubleshooting/03-resolving-cnfe-and-cdnfe-in-osgi-bundles.markdown
+++ b/develop/tutorials/articles/310-troubleshooting/03-resolving-cnfe-and-cdnfe-in-osgi-bundles.markdown
@@ -17,6 +17,7 @@ In OSGi environments, however, there are additional cases where a
     module. 
 3.  The missing class belongs to a global library, either at the @product@ 
     webapp scope or the application server scope. 
+4.  The missing class belongs to a Java runtime package.  
 
 This tutorial explains how to handle each case.
 
@@ -110,8 +111,24 @@ from a global library), you can add the package to that module's `bnd.bnd`
 exports. You should **NOT**, however, undertake this lightly. The package would
 already be be exported if Liferay intended for it to be available. 
 
+## Case 4: The Missing Class Belongs to a Java Runtime Package [](id=case-4-the-missing-class-belongs-to-a-java-runtime-package)
+
+In this case, the class belongs to Java's `rt.jar` but the package isn't
+specified in the OSGi Framework's boot delegation list. `rt.jar`'s `java.*`
+packages are its only ones available on the classpath automatically; its other
+packages must be specified in the boot delegation list be on the classpath.
+
+Here's how to add packages to the boot delegation list:
+
+1.  In a `portal-ext.properties` file, override
+    [portal property `org.osgi.framework.bootdelegation`](@platform-ref@/7.0-latest/propertiesdoc/portal.properties.html#Module%20Framework).
+    Preserve its current list. 
+2.  Add the missing class's package to the list. 
+
 ## Related Topics [](id=related-topics)
 
 [Backing up Liferay Installations](/discover/deployment/-/knowledge_base/7-0/backing-up-a-liferay-installation)
 
 [Adding Third Party Libraries to a Module](/develop/tutorials/-/knowledge_base/7-0/adding-third-party-libraries-to-a-module)
+
+[Bundle Classloading Flow](/develop/tutorials/-/knowledge_base/7-0/bundle-classloading-flow)


### PR DESCRIPTION
Hi Jesse,

This documentation explains various classloader related hurdles a developer might have to go through to create or upgrade a Spring MVC portlet. I drew from Minhchau's comments from https://issues.liferay.com/browse/LPP-26781 to produce these improvements 

The best article to review first is 00-spring-mvc-intro.markdown. The 07-upgrading* article references it.

I'll have Minhchau review the docs after you review them for the Core Infra team. Thanks!

https://issues.liferay.com/browse/LRDOCS-3978